### PR TITLE
Refactor: rename TLS configuration options to keep consistency with irmago

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Using a JSON configuration file:
     
     // optional (specify either both or none)
     // if present, enables TLS
-    "tls_cert": "/path/to/cert.pem",
-    "tls_privkey": "/path/to/privkey.pem"
+    "tls_cert_file": "/path/to/cert.pem",
+    "tls_privkey_file": "/path/to/privkey.pem"
 }
 ```
 

--- a/main.go
+++ b/main.go
@@ -28,8 +28,8 @@ type Configuration struct {
 	Clients       map[string]Client `json:"clients"`
 
 	// TLS configuration
-	TLSCertificate string `json:"tls_cert"`
-	TLSPrivateKey  string `json:"tls_privkey"`
+	TLSCertificateFile string `json:"tls_cert_file"`
+	TLSPrivateKeyFile  string `json:"tls_privkey_file"`
 }
 
 type Client struct {
@@ -98,9 +98,9 @@ func checkConfig(conf *Configuration) {
 		}
 	}
 
-	if (conf.TLSPrivateKey != "" && conf.TLSCertificate == "") ||
-		(conf.TLSCertificate != "" && conf.TLSPrivateKey == "") {
-		die("either configure both or none of tls_cert and tls_privkey", nil)
+	if (conf.TLSPrivateKeyFile != "" && conf.TLSCertificateFile == "") ||
+		(conf.TLSCertificateFile != "" && conf.TLSPrivateKeyFile == "") {
+		die("either configure both or none of tls_cert_file and tls_privkey_file", nil)
 	}
 
 	if err := irmaserver.Initialize(conf.Configuration); err != nil {

--- a/server.go
+++ b/server.go
@@ -56,8 +56,8 @@ func start(conf *Configuration) error {
 
 	fullAddr := fmt.Sprintf("%s:%d", conf.ListenAddress, conf.Port)
 
-	if conf.TLSPrivateKey != "" {
-		return server.FilterStopError(http.ListenAndServeTLS(fullAddr, conf.TLSCertificate, conf.TLSPrivateKey, handler))
+	if conf.TLSPrivateKeyFile != "" {
+		return server.FilterStopError(http.ListenAndServeTLS(fullAddr, conf.TLSCertificateFile, conf.TLSPrivateKeyFile, handler))
 	}
 	return server.FilterStopError(http.ListenAndServe(fullAddr, handler))
 }


### PR DESCRIPTION
@dthtab mentioned that there are subtile differences between the TLS configuration options of the irmago requestorserver and this one. For consistency it would be better to have matching names.