### PR TITLE
Improve naming, mainly switching from 'username' to 'loginCode'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # UniqueID issuer
 
-An IRMA issuer of randomly generated usernames.
+An IRMA issuer of randomly generated login codes.
 
 ## Description
 
-This project contains a HTTP server which issues an IRMA credential containing a random username, and the name of the organization on behalf of which the username was issued (the client), as follows:
+This project contains an HTTP server which issues an IRMA credential containing a random login code, and the name of the organization on behalf of which the login code was issued (the client), as follows:
 
-1. The client starts the session by invoking `POST /session`, authenticating itself using a preshared token in the `Authorization` HTTP header.
-2. Using a [builtin IRMA server library](https://irma.app/docs/irma-server-lib/), this server starts an issuance session for a credential containing a new random username, and the client's name as specified by the configuration (see below). It responds to the client with an [IRMA session package](https://irma.app/docs/api-irma-server/#post-session), who forwards it to its frontend. The [`irma-frontend`](https://irma.app/docs/irma-frontend/) library of the client's frontend uses that to show a QR code or universal link for the user's IRMA app.
+1. The client starts the session by invoking `POST /session`, authenticating itself using a pre-shared token in the `Authorization` HTTP header.
+2. Using a [builtin IRMA server library](https://irma.app/docs/irma-server-lib/), this server starts an issuance session for a credential containing a new random login code, and the client's organization name as specified by the configuration (see below). It responds to the client with an [IRMA session package](https://irma.app/docs/api-irma-server/#post-session), who forwards it to its frontend. The [`irma-frontend`](https://irma.app/docs/irma-frontend/) library of the client's frontend uses that to show a QR code or universal link for the user's IRMA app.
 3. The user's IRMA app and this server perform the issuance session.
 
 ## Getting Started
@@ -32,12 +32,12 @@ Using a JSON configuration file:
     "schemes_path": "/path/to/schemes", // optional
     "url": "https://example.com/",      // public URL to this server
 
-    // Attribute IDs in which the username and client name are to be issued
+    // Attribute IDs in which the login code and client name are to be issued
     // Must be part of the same credential type
-    "username_attr": "irma-demo.sidn-pbdf.uniqueid.username",
-    "client_attr": "irma-demo.sidn-pbdf.uniqueid.website",
+    "logincode_attr": "irma-demo.sidn-pbdf.uniqueid.uniqueid",
+    "client_attr": "irma-demo.sidn-pbdf.uniqueid.organization",
     
-    "username_length": 12, // default value
+    "logincode_length": 12, // default value
 
     "listen_addr": "0.0.0.0",
     "port": 1234,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UniqueID issuer
 
-An IRMA issuer of randomly generated login codes.
+An IRMA issuer of randomly generated login codes that can be used as unique random usernames in for example a website.
 
 ## Description
 

--- a/conf.example.json
+++ b/conf.example.json
@@ -3,8 +3,8 @@
     "enable_sse": true,
     "verbose": 2,
 
-    "client_attr": "irma-demo.IRMATube.member.type",
-    "username_attr": "irma-demo.IRMATube.member.id",
+    "logincode_attr": "irma-demo.sidn-pbdf.uniqueid.uniqueid",
+    "client_attr": "irma-demo.sidn-pbdf.uniqueid.organization",
 
     "port": 1234,
     "clients": {

--- a/main.go
+++ b/main.go
@@ -18,10 +18,10 @@ const authTokenMinLength = 20
 type Configuration struct {
 	*server.Configuration
 
-	ClientAttr   irma.AttributeTypeIdentifier `json:"client_attr"`
-	UsernameAttr irma.AttributeTypeIdentifier `json:"username_attr"`
+	ClientAttr    irma.AttributeTypeIdentifier `json:"client_attr"`
+	LoginCodeAttr irma.AttributeTypeIdentifier `json:"logincode_attr"`
 
-	UsernameLength uint `json:"username_length"`
+	LoginCodeLength uint `json:"logincode_length"`
 
 	ListenAddress string            `json:"listen_addr"`
 	Port          uint              `json:"port"`
@@ -107,8 +107,8 @@ func checkConfig(conf *Configuration) {
 		die("failed to configure IRMA server", err)
 	}
 
-	if conf.ClientAttr.CredentialTypeIdentifier() != conf.UsernameAttr.CredentialTypeIdentifier() {
-		msg := fmt.Sprintf("attributes %s and %s do not belong to the same credential type", conf.ClientAttr, conf.UsernameAttr)
+	if conf.ClientAttr.CredentialTypeIdentifier() != conf.LoginCodeAttr.CredentialTypeIdentifier() {
+		msg := fmt.Sprintf("attributes %s and %s do not belong to the same credential type", conf.ClientAttr, conf.LoginCodeAttr)
 		die(msg, nil)
 	}
 
@@ -118,14 +118,14 @@ func checkConfig(conf *Configuration) {
 	if credtype == nil {
 		die("nonexistent credential type: "+credid.String(), nil)
 	}
-	for _, attr := range []irma.AttributeTypeIdentifier{conf.ClientAttr, conf.UsernameAttr} {
+	for _, attr := range []irma.AttributeTypeIdentifier{conf.ClientAttr, conf.LoginCodeAttr} {
 		if !credtype.ContainsAttribute(attr) {
 			die(fmt.Sprintf("credential type %s has no attribute %s", credid, attr.Name()), nil)
 		}
 	}
 
-	if conf.UsernameLength == 0 {
-		conf.UsernameLength = usernameDefaultLength
+	if conf.LoginCodeLength == 0 {
+		conf.LoginCodeLength = loginCodeDefaultLength
 	}
 }
 


### PR DESCRIPTION
In the scheme naming login code was preferred to username. For consistency I'd like these changes here, too. I don't mind if we use 'loginCode' or 'logincode'. Maybe you have a preference here.

!! Please be aware that this change also introduces a change in the configuration parameters !!