### PR TITLE
Docs: added instructions about how to start an issuing session

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ The TLS configuration fields are optional. If present, the server will accept TL
 
 ### Executing
 
-```
-uniqueid-issuer /path/to/config.json
-```
+You can run the issuer as follows.
+
+    uniqueid-issuer /path/to/config.json
+
+Subsequently, you can start an issuing session using the `irma` CLI tool.
+
+    go install github.com/privacybydesign/irmago/irma@master
+    irma session --from-package $(curl -X POST -H "Authorization: SecretPresharedToken" http://localhost:1234/session)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ You can run the issuer as follows.
 
     uniqueid-issuer /path/to/config.json
 
+For a quick start, you can use the example configuration.
+
+    uniqueid-issuer ./conf.example.json
+
 Subsequently, you can start an issuing session using the `irma` CLI tool.
 
     go install github.com/privacybydesign/irmago/irma@master


### PR DESCRIPTION
Instructions on how to test using https://github.com/privacybydesign/irmago/pull/203

### Note

Currently, the server fails when using SSE in verbose mode. This is fixed by https://github.com/privacybydesign/irmago/pull/207 . After this is merged, we can apply this fix here.